### PR TITLE
Check if session.userId is defined before calling User.findOne

### DIFF
--- a/src/helpers/AuthenticationChecker.ts
+++ b/src/helpers/AuthenticationChecker.ts
@@ -6,6 +6,10 @@ export const AuthenticationChecker: AuthChecker<ContextType> = async (
   { context },
   roles,
 ) => {
+  if (!context.req.session.userId) {
+    return false;
+  }
+
   const user = await User.findOneOrFail(context.req.session.userId);
 
   if (!roles.includes(String(user.userType))) {


### PR DESCRIPTION
`User.findOne(undefined)` will return the first entry in the users table, which means that `User.findOne(session.userId)` will always be define even if the `session.userId` is undefined. So a check on the userId is needed.